### PR TITLE
Revert to using OpenJDK as the base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG JDK_VERSION
 
-FROM azul/zulu-openjdk-alpine:$JDK_VERSION
+FROM openjdk:$JDK_VERSION-jdk-slim-buster
 
 # Env variables
 ARG JDK_VERSION
@@ -11,21 +11,25 @@ ARG DOCKER_COMPOSE_VERSION
 ENV DOCKER_VERSION ${DOCKER_VERSION:-19.03.5}
 ENV DOCKER_COMPOSE_VERSION ${DOCKER_COMPOSE_VERSION:-1.25.3}
 
+#Install build stuff
+RUN set -eux; \
+  apt-get update; \
+  apt-get install -y --no-install-recommends curl
+
 # Install Docker
 RUN set -eux; \
-      wget -c https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_VERSION.tgz -O - | tar xfzv - --strip-components 1 --directory /usr/local/bin/; \
-      dockerd --version; \
-      docker --version
+  curl -L https://download.docker.com/linux/static/stable/x86_64/docker-$DOCKER_VERSION.tgz | tar xfzv - --strip-components 1 --directory /usr/local/bin/; \
+  dockerd --version; \
+  docker --version
 
 # Install Docker Compose
-RUN apk --update add py-pip
-RUN apk --update add --virtual build-dependencies gcc python2-dev libffi-dev openssl-dev musl-dev make; \
-  pip install -U docker-compose==${DOCKER_COMPOSE_VERSION}; \
-  apk del build-dependencies; \
-  rm -rf `find / -regex '.*\.py[co]'`; \
+RUN set -eux; \
+  curl -L "https://github.com/docker/compose/releases/download/$DOCKER_COMPOSE_VERSION/docker-compose-$(uname -s)-$(uname -m)" -o /usr/bin/docker-compose; \
+  chmod 755 /usr/bin/docker-compose; \
   docker-compose --version
 
 # Clean up
 RUN set -eux; \
-      rm -f /usr/local/openjdk-$JDK_VERSION/src.zip
+  apt-get clean; \
+  rm -f /usr/local/openjdk-$JDK_VERSION/src.zip
 


### PR DESCRIPTION
The problems with musl far outweight the reduced size of the image.